### PR TITLE
Make route_id in predictions_for_stop optional

### DIFF
--- a/py_nextbus/client.py
+++ b/py_nextbus/client.py
@@ -89,7 +89,7 @@ class NextBusClient:
     def predictions_for_stop(
         self,
         stop_id: str | int,
-        route_id: str,
+        route_id: str | None = None,
         direction_id: str | None = None,
         agency_id: str | None = None,
         unfiltered: bool = False,
@@ -102,15 +102,19 @@ class NextBusClient:
         if direction_id:
             params["direction"] = direction_id
 
+        route_component = ""
+        if route_id:
+            route_component = f"routes/{route_id}/"
+
         result = self._get(
-            f"agencies/{agency_id}/routes/{route_id}/stops/{stop_id}/predictions",
+            f"agencies/{agency_id}/{route_component}stops/{stop_id}/predictions",
             params,
         )
 
         predictions = cast(list[dict[str, Any]], result)
 
-        # If unfiltered, return all predictions as the API returned them
-        if unfiltered:
+        # If unfiltered or route not provided, return all predictions as the API returned them
+        if unfiltered or not route_id:
             return predictions
 
         # HACK: Filter predictions based on stop and route because the API seems to ignore the route

--- a/py_nextbus/client.py
+++ b/py_nextbus/client.py
@@ -92,7 +92,6 @@ class NextBusClient:
         route_id: str | None = None,
         direction_id: str | None = None,
         agency_id: str | None = None,
-        unfiltered: bool = False,
     ) -> list[dict[str, Any]]:
         agency_id = agency_id or self.agency_id
         if not agency_id:
@@ -113,8 +112,8 @@ class NextBusClient:
 
         predictions = cast(list[dict[str, Any]], result)
 
-        # If unfiltered or route not provided, return all predictions as the API returned them
-        if unfiltered or not route_id:
+        # If route not provided, return all predictions as the API returned them
+        if not route_id:
             return predictions
 
         # HACK: Filter predictions based on stop and route because the API seems to ignore the route

--- a/py_nextbus/client.py
+++ b/py_nextbus/client.py
@@ -99,6 +99,8 @@ class NextBusClient:
 
         params: dict[str, Any] = {"coincident": True}
         if direction_id:
+            if not route_id:
+                raise NextBusValidationError("Direction ID provided without route ID")
             params["direction"] = direction_id
 
         route_component = ""
@@ -127,7 +129,7 @@ class NextBusClient:
         ]
 
         # HACK: Filter predictions based on direction in case the API returns extra predictions
-        if direction_id is not None:
+        if direction_id:
             for prediction_result in predictions:
                 prediction_result["values"] = [
                     prediction

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as readme:
 
 setup(
     name="py_nextbusnext",
-    version="2.0.4",
+    version="2.0.5",
     author="ViViDboarder",
     description="Minimalistic Python client for the NextBus public API for real-time transit "
     "arrival data",

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import unittest.mock
 
 from py_nextbus.client import NextBusClient
-from tests.helpers.mock_responses import MOCK_PREDICTIONS_RESPONSE
+from tests.helpers.mock_responses import MOCK_PREDICTIONS_RESPONSE_NO_ROUTE
+from tests.helpers.mock_responses import MOCK_PREDICTIONS_RESPONSE_WITH_ROUTE
 from tests.helpers.mock_responses import TEST_AGENCY_ID
 from tests.helpers.mock_responses import TEST_DIRECTION_ID
 from tests.helpers.mock_responses import TEST_ROUTE_ID
@@ -16,8 +17,26 @@ class TestNextBusClient(unittest.TestCase):
         self.client = NextBusClient()
 
     @unittest.mock.patch("py_nextbus.client.NextBusClient._get")
-    def test_predictions_for_stop(self, mock_get):
-        mock_get.return_value = MOCK_PREDICTIONS_RESPONSE
+    def test_predictions_for_stop_no_route(self, mock_get):
+        mock_get.return_value = MOCK_PREDICTIONS_RESPONSE_NO_ROUTE
+
+        result = self.client.predictions_for_stop(
+            TEST_STOP_ID,
+            agency_id=TEST_AGENCY_ID
+        )
+
+        self.assertEqual({r["stop"]["id"] for r in result}, {TEST_STOP_ID})
+        self.assertEqual(len(result), 3) # Results include all routes
+
+        mock_get.assert_called_once()
+        mock_get.assert_called_with(
+            f"agencies/{TEST_AGENCY_ID}/stops/{TEST_STOP_ID}/predictions",
+            {"coincident": True},
+        )
+
+    @unittest.mock.patch("py_nextbus.client.NextBusClient._get")
+    def test_predictions_for_stop_with_route(self, mock_get):
+        mock_get.return_value = MOCK_PREDICTIONS_RESPONSE_WITH_ROUTE
 
         result = self.client.predictions_for_stop(
             TEST_STOP_ID,

--- a/tests/helpers/mock_responses.py
+++ b/tests/helpers/mock_responses.py
@@ -105,7 +105,143 @@ MOCK_ROUTE_DETAILS_RESPONSE = {
     "timestamp": "2024-06-23T03:06:58Z",
 }
 
-MOCK_PREDICTIONS_RESPONSE = [
+MOCK_PREDICTIONS_RESPONSE_NO_ROUTE = [
+  {
+    "serverTimestamp": 1724038210798,
+    "nxbs2RedirectUrl": "",
+    "route": {
+      "id": "LOWL",
+      "title": "Lowl Owl Taraval",
+      "description": "10pm-5am nightly",
+      "color": "666666",
+      "textColor": "ffffff",
+      "hidden": False
+    },
+    "stop": {
+      "id": "5184",
+      "lat": 37.8071299,
+      "lon": -122.41732,
+      "name": "Jones St & Beach St",
+      "code": "15184",
+      "hidden": False,
+      "showDestinationSelector": True,
+      "route": "LOWL"
+    },
+    "values": []
+  },
+  {
+    "serverTimestamp": 1724038210798,
+    "nxbs2RedirectUrl": "",
+    "route": {
+      "id": "FBUS",
+      "title": "Fbus Market & Wharves",
+      "description": "",
+      "color": "b49a36",
+      "textColor": "000000",
+      "hidden": False
+    },
+    "stop": {
+      "id": "5184",
+      "lat": 37.8071299,
+      "lon": -122.41732,
+      "name": "Jones St & Beach St",
+      "code": "15184",
+      "hidden": False,
+      "showDestinationSelector": True,
+      "route": "FBUS"
+    },
+    "values": []
+  },
+  {
+    "serverTimestamp": 1724038210798,
+    "nxbs2RedirectUrl": "",
+    "route": {
+      "id": "F",
+      "title": "F Market & Wharves",
+      "description": "7am-10pm daily",
+      "color": "b49a36",
+      "textColor": "000000",
+      "hidden": False
+    },
+    "stop": {
+      "id": "5184",
+      "lat": 37.8071299,
+      "lon": -122.41732,
+      "name": "Jones St & Beach St",
+      "code": "15184",
+      "hidden": False,
+      "showDestinationSelector": True,
+      "route": "F"
+    },
+    "values": [
+      {
+        "timestamp": 1724038309178,
+        "minutes": 1,
+        "affectedByLayover": True,
+        "isDeparture": True,
+        "occupancyStatus": -1,
+        "occupancyDescription": "Unknown",
+        "vehiclesInConsist": 1,
+        "linkedVehicleIds": "1078",
+        "vehicleId": "1078",
+        "vehicleType": "Historic Street Car_VC1",
+        "direction": {
+          "id": "F_0_var1",
+          "name": "Castro + Market",
+          "destinationName": "Castro + Market"
+        },
+        "tripId": "11593249_M13",
+        "delay": 0,
+        "predUsingNavigationTm": False,
+        "departure": True
+      },
+      {
+        "timestamp": 1724039160000,
+        "minutes": 15,
+        "affectedByLayover": True,
+        "isDeparture": True,
+        "occupancyStatus": -1,
+        "occupancyDescription": "Unknown",
+        "vehiclesInConsist": 1,
+        "linkedVehicleIds": "1080",
+        "vehicleId": "1080",
+        "vehicleType": "Historic Street Car_VC1",
+        "direction": {
+          "id": "F_0_var0",
+          "name": "Castro",
+          "destinationName": "Castro"
+        },
+        "tripId": "11593252_M13",
+        "delay": 0,
+        "predUsingNavigationTm": False,
+        "departure": True
+      },
+      {
+        "timestamp": 1724041320000,
+        "minutes": 51,
+        "affectedByLayover": True,
+        "isDeparture": True,
+        "occupancyStatus": -1,
+        "occupancyDescription": "Unknown",
+        "vehiclesInConsist": 1,
+        "linkedVehicleIds": "1056",
+        "vehicleId": "1056",
+        "vehicleType": "Historic Street Car_VC1",
+        "direction": {
+          "id": "F_0_var1",
+          "name": "Castro + Market",
+          "destinationName": "Castro + Market"
+        },
+        "tripId": "11593256_M13",
+        "delay": 0,
+        "predUsingNavigationTm": False,
+        "departure": True
+      }
+    ]
+  }
+]
+
+MOCK_PREDICTIONS_RESPONSE_WITH_ROUTE = [
     {
         "serverTimestamp": 1720034290432,
         "nxbs2RedirectUrl": "",


### PR DESCRIPTION
The new NextBus/UmoIQ API supports URLs with the `route_id` segment omitted, like `api/pub/v1/agencies/sfmta-cis/stops/7999/predictions`. This is useful when multiple complementary routes use the same stop, such as the SFMTA `N` (light rail sharing traffic lane with cars and buses), `NBUS` (alternate bus service), and `NOWL` (overnight bus service). 

This PR extends the `predictions_for_stop` API by making the `route_id` param optional. I have tested this both with and without the parameter provided. I have also bumped the version.

I would like to integrate this functionality into the ha nextbus integration so that a single entity can optionally represent the combined predictions for all routes at a stop.