### PR TITLE
Remove python 3.9 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
             "tests",
         ]
     ),
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     install_requires=[
         "requests",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39, 310, 311, 312, 313, 3}
+envlist = py{310, 311, 312, 313, 3}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
It's nearing EOL and probably will be around the next release